### PR TITLE
add endpoint PATCH /api/articles/:article_id, TD5

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -11,7 +11,7 @@ afterAll(() => {
 });
 
 describe("ALL - invalid routes", () => {
-  test("status 404: responds with appropriate error when incorrect route", () => {
+  test("status:404, responds with appropriate error when incorrect route", () => {
     return request(app)
       .get("/api/toppicks")
       .expect(404)
@@ -43,7 +43,7 @@ describe("GET /api/topics", () => {
 });
 
 describe("GET /api/articles/:article_id", () => {
-  test("status 200: should return an article object with correct properties", () => {
+  test("status:200, should return an article object with correct properties", () => {
     return request(app)
       .get("/api/articles/1")
       .expect(200)
@@ -74,6 +74,47 @@ describe("GET /api/articles/:article_id", () => {
   test("status:400, gives correct error message when given invalid article id", () => {
     return request(app)
       .get("/api/articles/fish")
+      .expect(400)
+      .then((response) => {
+        expect(response.body.msg).toBe("Invalid Request");
+      });
+  });
+});
+
+describe("PATCH /api/articles/:article_id", () => {
+  test("status:200, updates correct article and returns updated object, for incrementing vote", () => {
+    const articleUpdate1 = {
+      inc_votes: 10,
+    };
+    return request(app)
+      .patch("/api/articles/1")
+      .send(articleUpdate1)
+      .expect(200)
+      .then(({ body }) => {
+        const { article } = body;
+        expect(article).toBeInstanceOf(Object);
+        expect(article.votes).toEqual(110);
+      });
+  });
+  test("status:200, updates correct article and returns updated object, for decrementing vote", () => {
+    const articleUpdate = {
+      inc_votes: -50,
+    };
+    return request(app)
+      .patch("/api/articles/2")
+      .send(articleUpdate)
+      .expect(200)
+      .then(({ body }) => {
+        const { article } = body;
+        expect(article).toBeInstanceOf(Object);
+        expect(article.votes).toEqual(-50);
+      });
+  });
+  test("status:400, gives correct error message when given invalid votes increment", () => {
+    const articleUpdate = { inc_votes: "fish" };
+    return request(app)
+      .patch("/api/articles/1")
+      .send(articleUpdate)
       .expect(400)
       .then((response) => {
         expect(response.body.msg).toBe("Invalid Request");

--- a/app.js
+++ b/app.js
@@ -2,13 +2,16 @@ const express = require("express");
 const {
   getTopics,
   getArticleById,
+  patchArticleById,
 } = require("./controllers/topics.controllers");
 
 const app = express();
+app.use(express.json());
 
 app.get("/api/topics", getTopics);
 
 app.get("/api/articles/:article_id", getArticleById);
+app.patch("/api/articles/:article_id", patchArticleById);
 
 app.all("*", (req, res) => {
   res.status(404).send({ msg: "Invalid route" });

--- a/controllers/topics.controllers.js
+++ b/controllers/topics.controllers.js
@@ -1,4 +1,8 @@
-const { selectTopics, selectArticleById } = require("../models/topics.models");
+const {
+  selectTopics,
+  selectArticleById,
+  updateArticleById,
+} = require("../models/topics.models");
 
 exports.getTopics = (req, res, next) => {
   selectTopics()
@@ -9,6 +13,14 @@ exports.getTopics = (req, res, next) => {
 exports.getArticleById = (req, res, next) => {
   const articleId = req.params.article_id;
   selectArticleById(articleId)
+    .then((article) => res.status(200).send({ article }))
+    .catch(next);
+};
+
+exports.patchArticleById = (req, res, next) => {
+  const articleId = req.params.article_id;
+  const newVotes = req.body.inc_votes;
+  updateArticleById(articleId, newVotes)
     .then((article) => res.status(200).send({ article }))
     .catch(next);
 };

--- a/models/topics.models.js
+++ b/models/topics.models.js
@@ -18,3 +18,21 @@ exports.selectArticleById = (articleId) => {
       }
     });
 };
+
+exports.updateArticleById = (articleId, newVotes) => {
+  return db
+    .query(
+      "UPDATE articles SET votes = votes + $1 WHERE article_id = $2 RETURNING *;",
+      [newVotes, articleId]
+    )
+    .then((article) => {
+      if (article.rows.length === 0) {
+        return Promise.reject({
+          status: 404,
+          msg: "Article does not exist",
+        });
+      } else {
+        return article.rows[0];
+      }
+    });
+};


### PR DESCRIPTION
PLEASE comment on whether:
a) error handling in topics.models.js, line 28-33 can be put elsewhere so i'm not repeating it on each endpoint method (same on both GET/PATCH)
b) i need to test for those errors in each endpoint method (i.e. tested for 404 in previous GET, but not in PATCH). if so, is there a way to test for the same thing without repetition?