### PR TITLE
td9 - add endpoint method GET /api/articles/:article_id/comments

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -194,6 +194,46 @@ describe("PATCH /api/articles/:article_id", () => {
   });
 });
 
+describe("GET /api/articles/:article_id/comments", () => {
+  test("status:200, responds with an array of comments objects", () => {
+    return request(app)
+      .get("/api/articles/9/comments")
+      .expect(200)
+      .then(({ body }) => {
+        const { comments } = body;
+        expect(comments).toBeInstanceOf(Array);
+        expect(comments.length).toBeGreaterThan(0);
+        comments.forEach((comment) => {
+          expect(comment).toEqual(
+            expect.objectContaining({
+              comment_id: expect.any(Number),
+              votes: expect.any(Number),
+              created_at: expect.any(String),
+              author: expect.any(String),
+              body: expect.any(String),
+            })
+          );
+        });
+      });
+  });
+  test("status:404, responds with correct error when no comments exist for supplied article_id", () => {
+    return request(app)
+      .get("/api/articles/4/comments")
+      .expect(404)
+      .then((response) => {
+        expect(response.body.msg).toBe("Resource not found");
+      });
+  });
+  test("status:400, gives correct error message when given invalid article id", () => {
+    return request(app)
+      .get("/api/articles/fish")
+      .expect(400)
+      .then((response) => {
+        expect(response.body.msg).toBe("Invalid Request");
+      });
+  });
+});
+
 ///////////////////////////////////////////
 
 //USERS tests

--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ const {
   getArticles,
   getArticleById,
   patchArticleById,
+  getCommentsByArticleId,
 } = require("./controllers/articles.controllers");
 
 const { getUsers } = require("./controllers/users.controllers");
@@ -19,6 +20,7 @@ app.get("/api/topics", getTopics);
 app.get("/api/articles", getArticles);
 app.get("/api/articles/:article_id", getArticleById);
 app.patch("/api/articles/:article_id", patchArticleById);
+app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
 
 app.all("*", (req, res) => {
   res.status(404).send({ msg: "Invalid route" });

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -2,6 +2,7 @@ const {
   selectArticles,
   selectArticleById,
   updateArticleById,
+  selectCommentsByArticleId,
 } = require("../models/articles.models");
 
 exports.getArticles = (req, res, next) => {
@@ -22,5 +23,12 @@ exports.patchArticleById = (req, res, next) => {
   const newVotes = req.body.inc_votes;
   updateArticleById(articleId, newVotes)
     .then((article) => res.status(200).send({ article }))
+    .catch(next);
+};
+
+exports.getCommentsByArticleId = (req, res, next) => {
+  const articleId = req.params.article_id;
+  selectCommentsByArticleId(articleId)
+    .then((comments) => res.status(200).send({ comments }))
     .catch(next);
 };

--- a/db/seeds/utils.js
+++ b/db/seeds/utils.js
@@ -1,3 +1,6 @@
+const format = require("pg-format");
+const db = require("../connection.js");
+
 exports.convertTimestampToDate = ({ created_at, ...otherProperties }) => {
   if (!created_at) return { ...otherProperties };
   return { created_at: new Date(created_at), ...otherProperties };
@@ -18,5 +21,15 @@ exports.formatComments = (comments, idLookup) => {
       author: created_by,
       ...this.convertTimestampToDate(restOfComment),
     };
+  });
+};
+
+exports.checkExists = (table, column, value) => {
+  const queryStr = format("SELECT * FROM %s WHERE %s = $1;", table, column);
+
+  return db.query(queryStr, [value]).then((dbOutput) => {
+    if (dbOutput.rows.length === 0) {
+      return Promise.reject({ status: 404, msg: "Resource not found" });
+    }
   });
 };

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,4 +1,5 @@
 const db = require("../db/connection.js");
+const { checkExists } = require("../db/seeds/utils");
 
 exports.selectArticles = () => {
   return db
@@ -40,6 +41,26 @@ exports.updateArticleById = (articleId, newVotes) => {
         });
       } else {
         return article.rows[0];
+      }
+    });
+};
+
+exports.selectCommentsByArticleId = (articleId) => {
+  return checkExists("comments", "comments.article_id", articleId)
+    .then(() => {
+      return db.query(
+        "SELECT comments.comment_id, comments.votes, comments.created_at, comments.author, comments.body FROM comments JOIN articles ON comments.article_id = articles.article_id WHERE articles.article_id = $1",
+        [articleId]
+      );
+    })
+    .then((comments) => {
+      if (comments.rows.length === 0) {
+        return Promise.reject({
+          status: 404,
+          msg: "Article does not exist",
+        });
+      } else {
+        return comments.rows;
       }
     });
 };


### PR DESCRIPTION
QUESTION: I've replicated the error from /api/articles/:article_id endpoint, testing 400 error for invalid article_id supplied. Am I right in thinking this needs to be re-tested for this endpoint/method? Please note I notice now I didn't add the "/comments" to the end of the endpoint, in bold below. Just added now and it still passes. Will update before merging if approved.

  test("status:400, gives correct error message when given invalid article id", () => {
    return request(app)
      **.get("/api/articles/fish")**
      .expect(400)
      .then((response) => {
        expect(response.body.msg).toBe("Invalid Request");
      });
  });